### PR TITLE
Reuse HttpClient

### DIFF
--- a/Colg UWP/Service/ApiBase.cs
+++ b/Colg UWP/Service/ApiBase.cs
@@ -17,7 +17,7 @@ namespace Colg_UWP.Service
 
         protected static async Task<string> GetPost(string uri, Dictionary<string, string> content)
         {
-            using (HttpClient client = HttpClientManager.CreateClient())
+            var client = HttpClientManager.ClientForCurrentLifeCycle;
             using (CancellationTokenSource cts = new CancellationTokenSource())
             {
                 Util.Logging.WriteLine($"Request {Environment.NewLine}{uri}");

--- a/Colg UWP/Util/HttpClientManager.cs
+++ b/Colg UWP/Util/HttpClientManager.cs
@@ -5,11 +5,18 @@ namespace Colg_UWP.Util
 {
     public static class HttpClientManager
     {
-        public static HttpClient CreateClient()
+        public static HttpClient ClientForCurrentLifeCycle { get; private set; }
+
+
+       
+
+
+        static HttpClientManager()
         {
-            HttpClient client = new HttpClient();
-            client.DefaultRequestHeaders.UserAgent.Add(new HttpProductInfoHeaderValue("Mozilla", "5.0"));
-            return client;
+            ClientForCurrentLifeCycle = new HttpClient();
+
+
         }
+
     }
 }


### PR DESCRIPTION
According to best practice, Httpclient should be reused during entire
app life cycle.
so use it